### PR TITLE
Use `run_exports.json` when available

### DIFF
--- a/conda_forge_feedstock_check_solvable/mamba_solver.py
+++ b/conda_forge_feedstock_check_solvable/mamba_solver.py
@@ -345,6 +345,7 @@ def _strip_anaconda_tokens(url):
         return url
 
 
+@functools.cache()
 def _fetch_json_zst(url):
     res = requests.get(url)
     compressed_binary = res.content

--- a/conda_forge_feedstock_check_solvable/mamba_solver.py
+++ b/conda_forge_feedstock_check_solvable/mamba_solver.py
@@ -346,7 +346,9 @@ def _strip_anaconda_tokens(url):
 
 
 def _fetch_json_zst(url):
-    ...
+    res = requests.get(url)
+    binary = res.content
+    return zstd.decompress(binary)
 
 
 @functools.lru_cache(maxsize=10240)

--- a/conda_forge_feedstock_check_solvable/mamba_solver.py
+++ b/conda_forge_feedstock_check_solvable/mamba_solver.py
@@ -345,7 +345,7 @@ def _strip_anaconda_tokens(url):
         return url
 
 
-@functools.cache()
+@functools.cache
 def _fetch_json_zst(url):
     res = requests.get(url)
     compressed_binary = res.content

--- a/conda_forge_feedstock_check_solvable/mamba_solver.py
+++ b/conda_forge_feedstock_check_solvable/mamba_solver.py
@@ -347,8 +347,9 @@ def _strip_anaconda_tokens(url):
 
 def _fetch_json_zst(url):
     res = requests.get(url)
-    binary = res.content
-    return zstd.decompress(binary)
+    compressed_binary = res.content
+    binary = zstd.decompress(compressed_binary)
+    return json.loads(binary.decode("utf-8"))
 
 
 @functools.lru_cache(maxsize=10240)

--- a/conda_forge_feedstock_check_solvable/mamba_solver.py
+++ b/conda_forge_feedstock_check_solvable/mamba_solver.py
@@ -356,7 +356,7 @@ def _get_run_export(link_tuple):
     """
     Given a tuple of (channel, file, json repodata) as returned by libmamba solver,
     fetch the run exports for the artifact. There are several possible sources:
-    
+
     1. CEP-12 run_exports.json file served in the channel/subdir (next to repodata.json)
     2. conda-forge-metadata fetchers (libcgraph, oci, etc)
     3. The full artifact (conda or tar.bz2) as a last resort
@@ -385,8 +385,8 @@ def _get_run_export(link_tuple):
         if filename.endswith(".conda"):
             rx = run_exports_json.get("packages.conda", {}).get(filename, {})
         else:
-            rx = run_exports_json.get("packages", {}).get(filename, {})    
-    
+            rx = run_exports_json.get("packages", {}).get(filename, {})
+
     # Second source: conda-forge-metadata fetchers
     if not rx:
         cd = download_channeldata(channel_url)
@@ -398,8 +398,9 @@ def _get_run_export(link_tuple):
                 backend="libcfgraph",
             )
             if artifact_data is not None:
-                rx = artifact_data.get("rendered_recipe", {}).get("build", {}).get("run_exports", {})
-    
+                rx = artifact_data.get("rendered_recipe", {}).get(
+                        "build", {}).get("run_exports", {})
+
             # Third source: download from the full artifact
             if not rx:
                 print_info(

--- a/conda_forge_feedstock_check_solvable/mamba_solver.py
+++ b/conda_forge_feedstock_check_solvable/mamba_solver.py
@@ -347,7 +347,11 @@ def _strip_anaconda_tokens(url):
 
 @functools.cache
 def _fetch_json_zst(url):
-    res = requests.get(url)
+    try:
+        res = requests.get(url)
+    except requests.RequestException:
+        # If the URL is invalid return None
+        return None
     compressed_binary = res.content
     binary = zstd.decompress(compressed_binary)
     return json.loads(binary.decode("utf-8"))

--- a/conda_forge_feedstock_check_solvable/mamba_solver.py
+++ b/conda_forge_feedstock_check_solvable/mamba_solver.py
@@ -385,9 +385,10 @@ def _get_run_export(link_tuple):
     run_exports_json = _fetch_json_zst(f"{channel_url}/{subdir}/run_exports.json.zst")
     if run_exports_json:
         if filename.endswith(".conda"):
-            rx = run_exports_json.get("packages.conda", {}).get(filename, {})
+            pkgs = run_exports_json.get("packages.conda", {})
         else:
-            rx = run_exports_json.get("packages", {}).get(filename, {})
+            pkgs = run_exports_json.get("packages.conda", {})
+        rx = pkgs.get(filename, {}).get("run_exports", {})
 
     # Second source: conda-forge-metadata fetchers
     if not rx:


### PR DESCRIPTION
Adding support for CEP-12 `run_exports.json` as a preferred source for run exports metadata.