### PR TITLE
DEP remove use of libcfgraph backend

### DIFF
--- a/conda_forge_feedstock_check_solvable/mamba_solver.py
+++ b/conda_forge_feedstock_check_solvable/mamba_solver.py
@@ -399,7 +399,6 @@ def _get_run_export(link_tuple):
                 channel,
                 subdir,
                 filename,
-                backend="libcfgraph",
             )
             if artifact_data is not None:
                 rx = (


### PR DESCRIPTION
This PR removes the use of the libcfgraph backend and instead use the default.