### PR TITLE
PERF use a hard coded list of max cuda versions

### DIFF
--- a/conda_forge_feedstock_check_solvable/utils.py
+++ b/conda_forge_feedstock_check_solvable/utils.py
@@ -26,6 +26,7 @@ DEFAULT_RUN_EXPORTS = {
 }
 
 MAX_GLIBC_MINOR = 50
+MAX_FUTURE_VERSION = 20
 
 # these characters are start requirements that do not need to be munged from
 # 1.1 to 1.1.*
@@ -54,12 +55,10 @@ MINIMUM_CUDA_VERS = [
     "11.6",
     "11.7",
     "11.8",
-    "12.0",
-    "12.1",
-    "12.2",
-    "12.3",
-    "12.4",
-    "12.5",
+] + [
+    f"{cuda_major}.{cuda_minor}"
+    for cuda_minor in range(MAX_FUTURE_VERSION)
+    for cuda_major in range(12, MAX_FUTURE_VERSION)
 ]
 
 MINIMUM_OSX_64_VERS = [
@@ -74,8 +73,8 @@ MINIMUM_OSX_64_VERS = [
 ]
 MINIMUM_OSX_ARM64_VERS = MINIMUM_OSX_64_VERS + [
     f"{osx_major}.{osx_minor}"
-    for osx_minor in range(0, 17)
-    for osx_major in range(11, 17)
+    for osx_minor in range(0, MAX_FUTURE_VERSION)
+    for osx_major in range(11, MAX_FUTURE_VERSION)
 ]
 
 PROBLEMATIC_REQS = {

--- a/conda_forge_feedstock_check_solvable/virtual_packages.py
+++ b/conda_forge_feedstock_check_solvable/virtual_packages.py
@@ -2,7 +2,6 @@ import atexit
 import functools
 import os
 import pathlib
-import subprocess
 import tempfile
 import time
 from collections import defaultdict
@@ -130,22 +129,8 @@ def virtual_package_repodata():
     for glibc_minor in range(12, MAX_GLIBC_MINOR + 1):
         repodata.add_package(FakePackage("__glibc", "2.%d" % glibc_minor))
 
-    # cuda - get from cuda-version on conda-forge
-    try:
-        cuda_pkgs = json.loads(
-            subprocess.check_output(
-                "CONDA_SUBDIR=linux-64 conda search cuda-version -c conda-forge --json",
-                shell=True,
-                text=True,
-                stderr=subprocess.PIPE,
-            )
-        )
-        cuda_vers = [pkg["version"] for pkg in cuda_pkgs["cuda-version"]]
-    except Exception:
-        cuda_vers = []
-    # extra hard coded list to make sure we don't miss anything
-    cuda_vers += MINIMUM_CUDA_VERS
-    cuda_vers = set(cuda_vers)
+    # cuda
+    cuda_vers = set(MINIMUM_CUDA_VERS)
     for cuda_ver in cuda_vers:
         repodata.add_package(FakePackage("__cuda", cuda_ver))
 


### PR DESCRIPTION
This PR switches the virtual packages to use a hard coded list of versions. I put the max at 20 and so we should be future proof for a while for CUDA (which is at 12 now).