### PR TITLE
BUG make sure to munge specs like conda-build before checking w/ rattler

### DIFF
--- a/conda_forge_feedstock_check_solvable/rattler_solver.py
+++ b/conda_forge_feedstock_check_solvable/rattler_solver.py
@@ -11,6 +11,7 @@ from rattler import Channel, MatchSpec, Platform, RepoDataRecord, solve
 
 from conda_forge_feedstock_check_solvable.utils import (
     DEFAULT_RUN_EXPORTS,
+    convert_spec_to_conda_build,
     get_run_exports,
     print_debug,
     print_warning,
@@ -96,8 +97,12 @@ class RattlerSolver:
         run_exports = copy.deepcopy(DEFAULT_RUN_EXPORTS)
 
         try:
-            _specs = [MatchSpec(s) for s in specs]
-            _constraints = [MatchSpec(c) for c in constraints] if constraints else None
+            _specs = [MatchSpec(convert_spec_to_conda_build(s)) for s in specs]
+            _constraints = (
+                [MatchSpec(convert_spec_to_conda_build(c)) for c in constraints]
+                if constraints
+                else None
+            )
 
             print_debug(
                 "RATTLER running solver for specs \n\n%s\n", pprint.pformat(_specs)
@@ -130,14 +135,16 @@ class RattlerSolver:
                 )
 
         except Exception as e:
+            __specs = [convert_spec_to_conda_build(s) for s in specs]
+            __constraints = [convert_spec_to_conda_build(s) for s in constraints or []]
             err = str(e)
             print_warning(
                 "RATTLER failed to solve specs \n\n%s\n\nwith "
                 "constraints \n\n%s\n\nfor channels "
                 "\n\n%s\n\non platform "
                 "\n\n%s\n\nThe reported errors are:\n\n%s\n",
-                textwrap.indent(pprint.pformat(specs), "    "),
-                textwrap.indent(pprint.pformat(constraints), "    "),
+                textwrap.indent(pprint.pformat(__specs), "    "),
+                textwrap.indent(pprint.pformat(__constraints), "    "),
                 textwrap.indent(pprint.pformat(self.channels), "    "),
                 textwrap.indent(pprint.pformat(self.platform_arch), "    "),
                 textwrap.indent(err, "    "),

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -389,3 +389,36 @@ def test_solvers_python(mamba_factory, rattler_factory):
         )
         assert set(mamba_solution or []) == set(rattler_solution or [])
         assert mamba_solvable == rattler_solvable
+
+
+def test_solvers_python3_pin(solver_factory):
+    specs = [
+        "tetgen",
+        "hdf5",
+        "libgfortran5 >=12.3.0",
+        "triangle",
+        "scipy",
+        "numpy",
+        "pytest-xdist",
+        "ncurses",
+        "pychrono >=7",
+        "cython",
+        "h5py * mpi_mpich_*",
+        "petsc4py",
+        "future",
+        "mpi4py",
+        "pytest",
+        "libgcc-ng >=12",
+        "h5py",
+        "openblas",
+        "python 3",
+        "hdf5 * mpi_mpich_*",
+        "libgfortran-ng",
+        "matplotlib-base",
+        "libstdcxx-ng >=12",
+    ]
+    channels = (virtual_package_repodata(), "conda-forge")
+    platform = "linux-64"
+    solver = solver_factory(channels, platform)
+    solvable, err, solution = solver.solve(specs)
+    assert solvable, (err, solution)


### PR DESCRIPTION
This PR makes sure to munge specs like `python 3` to `python 3.*` when using rattler.