### PR TITLE
fix: change pin_compatible to match conda-build

### DIFF
--- a/tests/biopython-feedstock/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/tests/biopython-feedstock/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -1,0 +1,27 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - c_stdlib_version
+  - cdt_name

--- a/tests/biopython-feedstock/recipe/meta.yaml
+++ b/tests/biopython-feedstock/recipe/meta.yaml
@@ -1,0 +1,110 @@
+{% set name = "biopython" %}
+{% set version = "1.84" %}
+{% set sha256 = "60fbe6f996e8a6866a42698c17e552127d99a9aab3259d6249fbaabd0e0cc7b4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  skip: true  # [py<39]
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+
+test:
+  imports:
+    - Bio
+    - Bio.Affy
+    - Bio.Align
+    - Bio.Align.Applications
+    - Bio.AlignIO
+    - Bio.Application
+    - Bio.Blast
+    - Bio.CAPS
+    - Bio.Cluster
+    - Bio.Compass
+    - Bio.Data
+    - Bio.Emboss
+    - Bio.Entrez
+    - Bio.ExPASy
+    - Bio.GenBank
+    - Bio.Geo
+    #Requires soft dependency reportlab
+    #- Bio.Graphics
+    #- Bio.Graphics.GenomeDiagram
+    - Bio.HMM
+    - Bio.KEGG
+    - Bio.KEGG.Compound
+    - Bio.KEGG.Enzyme
+    - Bio.KEGG.KGML
+    - Bio.KEGG.Map
+    - Bio.Medline
+    - Bio.NMR
+    - Bio.Nexus
+    - Bio.PDB
+    #Requires soft dependency mmtf-python
+    #- Bio.PDB.mmtf
+    - Bio.Pathway
+    - Bio.Pathway.Rep
+    - Bio.Phylo
+    - Bio.Phylo.Applications
+    - Bio.Phylo.PAML
+    - Bio.PopGen
+    - Bio.PopGen.GenePop
+    - Bio.Restriction
+    - Bio.SCOP
+    - Bio.SVDSuperimposer
+    - Bio.SearchIO
+    - Bio.SearchIO.BlastIO
+    - Bio.SearchIO.ExonerateIO
+    - Bio.SearchIO.HmmerIO
+    - Bio.SearchIO._model
+    - Bio.SeqIO
+    - Bio.SeqUtils
+    - Bio.Sequencing
+    - Bio.Sequencing.Applications
+    - Bio.SwissProt
+    - Bio.TogoWS
+    - Bio.UniGene
+    - Bio.UniProt
+    - Bio.codonalign
+    - Bio.cpairwise2
+    - Bio.motifs
+    - Bio.motifs.applications
+    - Bio.motifs.jaspar
+    - Bio.phenotype
+    - BioSQL
+
+about:
+  home: http://biopython.org
+  license: LicenseRef-Biopython
+  license_file: LICENSE.rst
+  summary: Collection of freely available tools for computational molecular biology
+  description: |
+    Biopython is a collection of freely available Python tools for
+    computational molecular biology
+  doc_url: http://biopython.org
+  dev_url: https://github.com/biopython/biopython
+
+extra:
+  recipe-maintainers:
+    - souravsingh
+    - peterjc

--- a/tests/test_check_solvable.py
+++ b/tests/test_check_solvable.py
@@ -190,6 +190,16 @@ def test_hpp_fcl_solvable_runs(solver):
     )
 
 
+@flaky
+def test_biopython_solvable_runs(solver):
+    feedstock_dir = os.path.join(os.path.dirname(__file__), "biopython-feedstock")
+    is_recipe_solvable(
+        feedstock_dir,
+        solver=solver,
+        verbosity=VERB,
+    )
+
+
 def clone_and_checkout_repo(base_path: pathlib.Path, origin_url: str, ref: str):
     subprocess.run(
         f"cd {base_path} && git clone {origin_url} repo",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -145,21 +145,23 @@ def test_replace_pin_compatible():
 
 def test_replace_pin_compatible_raises():
     with pytest.raises(ValueError) as e:
-        replace_pin_compatible(["pin_compatible('foo') mpi_*"], [])
+        replace_pin_compatible(["pin_compatible('foo') mpi_*"], [], strict=True)
     assert "Package foo not found in host" in str(e.value)
 
     with pytest.raises(ValueError) as e:
-        replace_pin_compatible(["pin_compatible('foo') mpi_*"], ["foo"])
+        replace_pin_compatible(["pin_compatible('foo') mpi_*"], ["foo"], strict=True)
     assert "Package found in host but no version" in str(e.value)
 
     with pytest.raises(ValueError) as e:
         replace_pin_compatible(
-            ["pin_compatible('foo', exact=True) mpi_*"], ["foo 14 dfgdfs"]
+            ["pin_compatible('foo', exact=True) mpi_*"], ["foo 14 dfgdfs"], strict=True
         )
     assert "Build string cannot be given for pin_compatible with exact=True!" in str(
         e.value
     )
 
     with pytest.raises(ValueError) as e:
-        replace_pin_compatible(["5 pin_compatible('foo') mpi_*"], ["foo 14 dfgdfs"])
+        replace_pin_compatible(
+            ["5 pin_compatible('foo') mpi_*"], ["foo 14 dfgdfs"], strict=True
+        )
     assert "Very odd" in str(e.value)


### PR DESCRIPTION
This PR changes the handling of pin_compatible to match the behavior of conda-build. If a pin_compatible statement is for a package for which there is no entry in host, we return the package without a constraint.