### PR TITLE
Add archspec packages for x86_64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           conda install --yes --file=requirements.txt
           conda install --yes pytest flaky pip python-build setuptools_scm>=7 setuptools>=45 toml
-          pip install -e .
+          pip install --no-deps --no-build-isolation -e .
 
       - name: test versions
         shell: bash -el {0}

--- a/.github/workflows/tests_mamba.yml
+++ b/.github/workflows/tests_mamba.yml
@@ -36,7 +36,7 @@ jobs:
           conda install --yes --file=requirements.txt
           conda install --yes --file=requirements-mamba.txt
           conda install --yes pytest flaky pip python-build setuptools_scm>=7 setuptools>=45 toml
-          pip install -e .
+          pip install --no-deps --no-build-isolation -e .
 
       - name: test versions
         shell: bash -el {0}

--- a/conda_forge_feedstock_check_solvable/rattler_solver.py
+++ b/conda_forge_feedstock_check_solvable/rattler_solver.py
@@ -7,16 +7,7 @@ import textwrap
 from functools import lru_cache
 from typing import List
 
-from rattler import (
-    Channel,
-    GenericVirtualPackage,
-    MatchSpec,
-    PackageName,
-    Platform,
-    RepoDataRecord,
-    Version,
-    solve,
-)
+from rattler import Channel, MatchSpec, Platform, RepoDataRecord, solve
 
 from conda_forge_feedstock_check_solvable.utils import (
     DEFAULT_RUN_EXPORTS,
@@ -55,17 +46,8 @@ class RattlerSolver:
             else:
                 _channels.append(c)
         self._channels = [Channel(c) for c in _channels]
-        self.platform_arch = Platform(platform_arch)
-        self._platforms = [self.platform_arch, Platform("noarch")]
-
-        self._virtual_packages = []
-        if str(self.platform_arch.arch) == "x86_64":
-            # Default to a modern x86_64 architecture to avoid erroneous solver failures
-            self._virtual_packages.append(
-                GenericVirtualPackage(
-                    PackageName("__archspec"), Version("1"), "x86_64_v3"
-                )
-            )
+        self.platform_arch = platform_arch
+        self._platforms = [Platform(self.platform_arch), Platform("noarch")]
 
     def solve(
         self,
@@ -136,7 +118,6 @@ class RattlerSolver:
                     platforms=self._platforms,
                     timeout=timeout,
                     constraints=_constraints,
-                    virtual_packages=self._virtual_packages,
                 )
             )
             success = True

--- a/conda_forge_feedstock_check_solvable/rattler_solver.py
+++ b/conda_forge_feedstock_check_solvable/rattler_solver.py
@@ -7,7 +7,16 @@ import textwrap
 from functools import lru_cache
 from typing import List
 
-from rattler import Channel, MatchSpec, Platform, RepoDataRecord, solve
+from rattler import (
+    Channel,
+    GenericVirtualPackage,
+    MatchSpec,
+    PackageName,
+    Platform,
+    RepoDataRecord,
+    Version,
+    solve,
+)
 
 from conda_forge_feedstock_check_solvable.utils import (
     DEFAULT_RUN_EXPORTS,
@@ -46,8 +55,17 @@ class RattlerSolver:
             else:
                 _channels.append(c)
         self._channels = [Channel(c) for c in _channels]
-        self.platform_arch = platform_arch
-        self._platforms = [Platform(self.platform_arch), Platform("noarch")]
+        self.platform_arch = Platform(platform_arch)
+        self._platforms = [self.platform_arch, Platform("noarch")]
+
+        self._virtual_packages = []
+        if str(self.platform_arch.arch) == "x86_64":
+            # Default to a modern x86_64 architecture to avoid erroneous solver failures
+            self._virtual_packages.append(
+                GenericVirtualPackage(
+                    PackageName("__archspec"), Version("1"), "x86_64_v3"
+                )
+            )
 
     def solve(
         self,
@@ -118,6 +136,7 @@ class RattlerSolver:
                     platforms=self._platforms,
                     timeout=timeout,
                     constraints=_constraints,
+                    virtual_packages=self._virtual_packages,
                 )
             )
             success = True

--- a/conda_forge_feedstock_check_solvable/utils.py
+++ b/conda_forge_feedstock_check_solvable/utils.py
@@ -32,6 +32,8 @@ DEFAULT_RUN_EXPORTS = {
 MAX_GLIBC_MINOR = 50
 MAX_FUTURE_VERSION = 20
 
+ARCHSPEC_X86_64_VERSIONS = ["x86_64_v1", "x86_64_v2", "x86_64_v3", "x86_64_v4"]
+
 # these characters are start requirements that do not need to be munged from
 # 1.1 to 1.1.*
 REQ_START_NOSTAR = ["!=", "==", ">", "<", ">=", "<=", "~="]

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -180,7 +180,6 @@ def test_solvers_archspec_with_virtual_package(solver_factory):
             (virtual_packages, "conda-forge", "defaults"), "linux-64"
         )
         out = solver.solve(["pythia8 8.312"])
-    print(out)
     assert out[0], out[1]
 
 

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -169,6 +169,13 @@ def test_solvers_nvcc_with_virtual_package(solver_factory):
 def test_solvers_archspec_with_virtual_package(solver_factory):
     with suppress_output():
         virtual_packages = virtual_package_repodata()
+
+        # Not having the fake virtual packages should fail
+        solver = solver_factory(("conda-forge", "defaults"), "linux-64")
+        out = solver.solve(["pythia8 8.312"])
+        assert not out[0], out[1]
+
+        # Including the fake virtual packages should succeed
         solver = solver_factory(
             (virtual_packages, "conda-forge", "defaults"), "linux-64"
         )

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -166,6 +166,18 @@ def test_solvers_nvcc_with_virtual_package(solver_factory):
 
 
 @flaky
+def test_solvers_archspec_with_virtual_package(solver_factory):
+    with suppress_output():
+        virtual_packages = virtual_package_repodata()
+        solver = solver_factory(
+            (virtual_packages, "conda-forge", "defaults"), "linux-64"
+        )
+        out = solver.solve(["pythia8 8.312"])
+    print(out)
+    assert out[0], out[1]
+
+
+@flaky
 def test_solvers_hang(solver_factory):
     with suppress_output():
         solver = solver_factory(("conda-forge", "defaults"), "osx-64")


### PR DESCRIPTION
When dependent packages require archspec the bot fails to solve despite the situation being okay. For example: https://conda-forge.org/status/migration/?name=root_base6328

This fixes this by always including the `x86_64_v3` virtual package when solving for x86_64. We could think of including other virtual packages but I'm not sure if it's worth it.