### PR TITLE
fix: try using pixi to clean up caches when running rattler-build

### DIFF
--- a/conda_forge_feedstock_check_solvable/rattler_build.py
+++ b/conda_forge_feedstock_check_solvable/rattler_build.py
@@ -27,6 +27,20 @@ def run_rattler_build(command):
         return status_code, stdout, stderr
     except Exception as e:
         return -1, "", str(e)
+    finally:
+        try:
+            subprocess.run(
+                [
+                    "pixi",
+                    "clean",
+                    "cache",
+                    "--yes",
+                ],
+                check=False,
+                capture_output=True,
+            )
+        except Exception as e:
+            print_debug("pixi clean cache command failed: %r", e)
 
 
 def invoke_rattler_build(

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests
 zstandard
 boltons>=23.0.0
 py-rattler>=0.9.0,<0.10a0
+pixi


### PR DESCRIPTION
It is unclear if this will help or if the tools even use the same caches. However, it is worth a try to see if we can unblock the bot v1 migrations.